### PR TITLE
Initial Plugin Implementation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,4 +19,4 @@ jobs:
       - name: asdf_plugin_test
         uses: asdf-vm/actions/plugin-test@v1
         with:
-          command: kubectl-buildkit --version
+          command: kubectl-buildkit version --help

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
+kubectl 1.21.11
 shellcheck 0.7.2
 shfmt 3.3.0

--- a/README.md
+++ b/README.md
@@ -16,10 +16,8 @@
 
 # Dependencies
 
-**TODO: adapt this section**
-
 - `bash`, `curl`, `tar`: generic POSIX utilities.
-- `SOME_ENV_VAR`: set this environment variable in your shell config to load the correct version of tool x.
+- `kubectl`
 
 # Install
 
@@ -44,7 +42,7 @@ asdf install kubectl-buildkit latest
 asdf global kubectl-buildkit latest
 
 # Now kubectl-buildkit commands are available
-kubectl-buildkit --version
+kubectl-buildkit version
 ```
 
 Check [asdf](https://github.com/asdf-vm/asdf) readme for more instructions on how to

--- a/bin/download
+++ b/bin/download
@@ -10,14 +10,13 @@ source "${plugin_dir}/lib/utils.bash"
 
 mkdir -p "$ASDF_DOWNLOAD_PATH"
 
-# TODO: Adapt this to proper extension and adapt extracting strategy.
 release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.tar.gz"
 
 # Download tar.gz file to the download directory
 download_release "$ASDF_INSTALL_VERSION" "$release_file"
 
 #  Extract contents of tar.gz file into the download directory
-tar -xzf "$release_file" -C "$ASDF_DOWNLOAD_PATH" --strip-components=1 || fail "Could not extract $release_file"
+tar -xzf "$release_file" -C "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $release_file"
 
 # Remove the tar.gz file since we don't need to keep it
 rm "$release_file"

--- a/contributing.md
+++ b/contributing.md
@@ -6,7 +6,7 @@ Testing Locally:
 asdf plugin test <plugin-name> <plugin-url> [--asdf-tool-version <version>] [--asdf-plugin-gitref <git-ref>] [test-command*]
 
 #
-asdf plugin test kubectl-buildkit https://github.com/ezcater/asdf-kubectl-buildkit.git "kubectl-buildkit --version"
+asdf plugin test kubectl-buildkit https://github.com/ezcater/asdf-kubectl-buildkit.git "kubectl-buildkit version --help"
 ```
 
 Tests are automatically run in GitHub Actions on push and PR.

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -2,10 +2,9 @@
 
 set -euo pipefail
 
-# TODO: Ensure this is the correct GitHub homepage where releases can be downloaded for kubectl-buildkit.
 GH_REPO="https://github.com/vmware-tanzu/buildkit-cli-for-kubectl"
 TOOL_NAME="kubectl-buildkit"
-TOOL_TEST="kubectl-buildkit --version"
+TOOL_TEST="kubectl-buildkit version --help"
 
 fail() {
   echo -e "asdf-$TOOL_NAME: $*"
@@ -14,7 +13,6 @@ fail() {
 
 curl_opts=(-fsSL)
 
-# NOTE: You might want to remove this if kubectl-buildkit is not hosted on GitHub releases.
 if [ -n "${GITHUB_API_TOKEN:-}" ]; then
   curl_opts=("${curl_opts[@]}" -H "Authorization: token $GITHUB_API_TOKEN")
 fi
@@ -27,12 +25,10 @@ sort_versions() {
 list_github_tags() {
   git ls-remote --tags --refs "$GH_REPO" |
     grep -o 'refs/tags/.*' | cut -d/ -f3- |
-    sed 's/^v//' # NOTE: You might want to adapt this sed to remove non-version strings from tags
+    sed 's/^v//'
 }
 
 list_all_versions() {
-  # TODO: Adapt this. By default we simply list the tag names from GitHub releases.
-  # Change this function if kubectl-buildkit has other means of determining installable versions.
   list_github_tags
 }
 
@@ -41,8 +37,20 @@ download_release() {
   version="$1"
   filename="$2"
 
-  # TODO: Adapt the release URL convention for kubectl-buildkit
-  url="$GH_REPO/archive/v${version}.tar.gz"
+  case $(uname) in
+  [dD]arwin*)
+    platform="darwin"
+    ;;
+  [Ll]inux*)
+    platform="linux"
+    ;;
+  *)
+    echo "Unsupported OS" 1>&2
+    return 1
+    ;;
+  esac
+
+  url="$GH_REPO/releases/download/v${version}/${platform}-v${version}.tgz"
 
   echo "* Downloading $TOOL_NAME release $version..."
   curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"
@@ -61,7 +69,6 @@ install_version() {
     mkdir -p "$install_path"
     cp -r "$ASDF_DOWNLOAD_PATH"/* "$install_path"
 
-    # TODO: Assert kubectl-buildkit executable exists.
     local tool_cmd
     tool_cmd="$(echo "$TOOL_TEST" | cut -d' ' -f1)"
     test -x "$install_path/$tool_cmd" || fail "Expected $install_path/$tool_cmd to be executable."


### PR DESCRIPTION
## Description

An initial implementation of an [asdf] plugin to install and manage [kubectl-buildkit] versions.

[asdf]: https://asdf-vm.com
[kubectl-buildkit]: https://github.com/vmware-tanzu/buildkit-cli-for-kubectl

## Motivation and Context

We would like to use [asdf] to install [kubectl-buildkit].

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Usage examples

As this plugin has not yet been accepted into the asdf-plugins repository, you'll need to use the following form to add it (once this PR is merged):

```shell
asdf plugin add kubectl-buildkit https://github.com/ezcater/asdf-kubectl-buildkit.git
```

To test out this PR, you'll need to switch the plugin to this PR's branch:

```shell
asdf plugin update kubectl-buildkit jb/DEVEX-1692/install-kubectl-build
```

Afterwards, you can use these commands to use this plugin:

```shell
# Show all installable versions
asdf list-all kubectl-buildkit

# Install specific version
asdf install kubectl-buildkit latest

# Set a version globally (on your ~/.tool-versions file)
asdf global kubectl-buildkit latest

# Now kubectl-buildkit commands are available
kubectl-buildkit version --help
```

## How Has This Been Tested?

- [x] Local testing
  - [x] linux
  - [x] osx
  - [ ] windows
- [ ] Not needed, feature very basic

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
