### PR TITLE
chore: pin GitHub Actions to commit SHAs [PinnR]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: asdf_plugin_test
-        uses: asdf-vm/actions/plugin-test@v1
+        uses: asdf-vm/actions/plugin-test@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1
         with:
           command: kubectl-buildkit version --help

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install asdf dependencies
-        uses: asdf-vm/actions/install@v1
+        uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1
 
       - name: Run ShellCheck
         run: scripts/shellcheck.bash
@@ -23,14 +23,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install asdf dependencies
-        uses: asdf-vm/actions/install@v1
+        uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1
 
       - name: List file to shfmt
         run: shfmt -f .
 
       - name: Run shfmt
         run: scripts/shfmt.bash
-

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # asdf-kubectl-buildkit [![Build](https://github.com/ezcater/asdf-kubectl-buildkit/actions/workflows/build.yml/badge.svg)](https://github.com/ezcater/asdf-kubectl-buildkit/actions/workflows/build.yml) [![Lint](https://github.com/ezcater/asdf-kubectl-buildkit/actions/workflows/lint.yml/badge.svg)](https://github.com/ezcater/asdf-kubectl-buildkit/actions/workflows/lint.yml)
 
 
-[kubectl-buildkit](https://github.com/vmware-tanzu/buildkit-cli-for-kubectl) plugin for the [asdf version manager](https://asdf-vm.com).
+[kubectl-buildkit](https://github.com/vmware-archive/buildkit-cli-for-kubectl) plugin for the [asdf version manager](https://asdf-vm.com).
 
 </div>
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-GH_REPO="https://github.com/vmware-tanzu/buildkit-cli-for-kubectl"
+GH_REPO="https://github.com/vmware-archive/buildkit-cli-for-kubectl"
 TOOL_NAME="kubectl-buildkit"
 TOOL_TEST="kubectl-buildkit version --help"
 


### PR DESCRIPTION
## PinnR: GitHub Actions Security Update

This PR pins GitHub Actions to specific commit SHAs to improve supply chain security.

### Why?

Floating tags like `v3` or branches like `main` can be moved to point to different commits, potentially introducing malicious code. Pinning to SHAs ensures the exact code version is used.

### Changes

| File | Action | Change |
|------|--------|--------|
| `build.yml` | `asdf-vm/actions/plugin-test` | `v1` → `b7bcd026f18772e44fe1026d729e1611cc435d47` (`v4.0.1`) |
| `lint.yml` | `actions/checkout` | `v2` → `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (`v6.0.2`) |
| `lint.yml` | `asdf-vm/actions/install` | `v1` → `b7bcd026f18772e44fe1026d729e1611cc435d47` (`v4.0.1`) |
| `lint.yml` | `actions/checkout` | `v2` → `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (`v6.0.2`) |
| `lint.yml` | `asdf-vm/actions/install` | `v1` → `b7bcd026f18772e44fe1026d729e1611cc435d47` (`v4.0.1`) |

### Note

If this PR is closed without merging, the branch `pinnR/GHA-Update-2026-04-16` will need to be deleted manually.

---
🤖 Generated by [PinnR](https://github.com/CyBirdSecurity/pinnr)