### PR TITLE
fix: use vmware-archive repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # asdf-kubectl-buildkit [![Build](https://github.com/ezcater/asdf-kubectl-buildkit/actions/workflows/build.yml/badge.svg)](https://github.com/ezcater/asdf-kubectl-buildkit/actions/workflows/build.yml) [![Lint](https://github.com/ezcater/asdf-kubectl-buildkit/actions/workflows/lint.yml/badge.svg)](https://github.com/ezcater/asdf-kubectl-buildkit/actions/workflows/lint.yml)
 
 
-[kubectl-buildkit](https://github.com/vmware-tanzu/buildkit-cli-for-kubectl) plugin for the [asdf version manager](https://asdf-vm.com).
+[kubectl-buildkit](https://github.com/vmware-archive/buildkit-cli-for-kubectl) plugin for the [asdf version manager](https://asdf-vm.com).
 
 </div>
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-GH_REPO="https://github.com/vmware-tanzu/buildkit-cli-for-kubectl"
+GH_REPO="https://github.com/vmware-archive/buildkit-cli-for-kubectl"
 TOOL_NAME="kubectl-buildkit"
 TOOL_TEST="kubectl-buildkit version --help"
 


### PR DESCRIPTION
Vmware moved their organization for this repository to vmware-archive. We're still using this tool, so update the plugin.